### PR TITLE
feat(webpanel): 优化文件操作体验：拖拽上传、快捷键保存与未保存提示

### DIFF
--- a/MSLX.WebPanel/src/pages/instance/files/components/FileEditor.vue
+++ b/MSLX.WebPanel/src/pages/instance/files/components/FileEditor.vue
@@ -113,6 +113,7 @@ onMounted(() => {
 
 onUnmounted(() => {
   observer?.disconnect();
+  window.removeEventListener('keydown', handleKeydown);
 });
 
 // --- 初始化内容 ---
@@ -197,6 +198,27 @@ const handleClose = () => {
 const handleConfirm = (closeDialog: boolean = true) => {
   emit('save', code.value, closeDialog);
 };
+
+const handleKeydown = (event: KeyboardEvent) => {
+  if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 's') {
+    event.preventDefault();
+    if (!props.loading) {
+      handleConfirm(false);
+    }
+  }
+};
+
+watch(
+  () => props.visible,
+  (visible) => {
+    if (visible) {
+      window.addEventListener('keydown', handleKeydown);
+    } else {
+      window.removeEventListener('keydown', handleKeydown);
+    }
+  },
+  { immediate: true },
+);
 </script>
 
 <template>

--- a/MSLX.WebPanel/src/pages/instance/files/components/FileEditor.vue
+++ b/MSLX.WebPanel/src/pages/instance/files/components/FileEditor.vue
@@ -25,9 +25,10 @@ const props = defineProps({
   fileName: String,
   content: String,
   loading: Boolean,
+  saveSuccess: Number,
 });
 
-const emit = defineEmits(['update:visible', 'save']);
+const emit = defineEmits(['update:visible', 'save', 'dirty-change']);
 
 // 处理代码格式化
 const handleFormat = async () => {
@@ -91,7 +92,23 @@ const handleFormat = async () => {
 };
 
 const code = ref('');
+const savedContent = ref('');
+const showCloseConfirm = ref(false);
+const dirty = computed(() => code.value !== savedContent.value);
 const isDarkMode = ref(false); // 存储当前是否为暗黑模式
+
+const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+  event.preventDefault();
+  event.returnValue = '';
+};
+
+const updateBeforeUnloadListener = () => {
+  const shouldWarn = props.visible && dirty.value;
+  window.removeEventListener('beforeunload', handleBeforeUnload);
+  if (shouldWarn) {
+    window.addEventListener('beforeunload', handleBeforeUnload);
+  }
+};
 
 // 主题变化监听
 let observer: MutationObserver | null = null;
@@ -114,13 +131,32 @@ onMounted(() => {
 onUnmounted(() => {
   observer?.disconnect();
   window.removeEventListener('keydown', handleKeydown);
+  window.removeEventListener('beforeunload', handleBeforeUnload);
 });
 
 // --- 初始化内容 ---
 watch(
   () => props.content,
   (newVal) => {
-    code.value = newVal || '';
+    const content = newVal || '';
+    code.value = content;
+    savedContent.value = content;
+  },
+  { immediate: true },
+);
+
+watch(
+  () => props.saveSuccess,
+  () => {
+    savedContent.value = code.value;
+  },
+);
+
+watch(
+  [() => props.visible, dirty],
+  () => {
+    emit('dirty-change', props.visible && dirty.value);
+    updateBeforeUnloadListener();
   },
   { immediate: true },
 );
@@ -191,12 +227,32 @@ const extensions = computed(() => {
   return result;
 });
 
-const handleClose = () => {
+const closeEditor = () => {
   emit('update:visible', false);
+};
+
+const handleClose = () => {
+  if (!dirty.value) {
+    closeEditor();
+    return;
+  }
+
+  showCloseConfirm.value = true;
+};
+
+const handleDiscard = () => {
+  showCloseConfirm.value = false;
+  closeEditor();
 };
 
 const handleConfirm = (closeDialog: boolean = true) => {
   emit('save', code.value, closeDialog);
+};
+
+const handleSaveAndClose = () => {
+  if (props.loading) return;
+  showCloseConfirm.value = false;
+  handleConfirm(true);
 };
 
 const handleKeydown = (event: KeyboardEvent) => {
@@ -224,13 +280,19 @@ watch(
 <template>
   <t-dialog
     :visible="visible"
-    :header="`正在编辑: ${fileName}`"
     width="90%"
     attach="body"
     top="2vh"
     class="editor-dialog"
     @close="handleClose"
   >
+    <template #header>
+      <div class="flex items-center gap-2">
+        <span>正在编辑: {{ fileName }}</span>
+        <span v-if="dirty" class="w-2 h-2 rounded-full bg-[var(--td-warning-color)]" title="未保存修改"></span>
+      </div>
+    </template>
+
     <div class="flex flex-col gap-2">
       <div
         class="border border-zinc-200/60 dark:border-zinc-700/60 rounded-xl overflow-hidden shadow-inner bg-white dark:bg-zinc-900/30"
@@ -271,9 +333,14 @@ watch(
         </div>
 
         <div class="flex items-center gap-2">
-          <t-popconfirm content="确认取消吗？未保存的内容将丢失" theme="warning" @confirm="handleClose">
-            <t-button variant="outline" class="!rounded-lg hover:!bg-zinc-100 dark:hover:!bg-zinc-800"> 取消 </t-button>
-          </t-popconfirm>
+          <t-button
+            variant="outline"
+            theme="default"
+            class="!rounded-lg hover:!bg-zinc-100 dark:hover:!bg-zinc-800"
+            @click="handleClose"
+          >
+            取消
+          </t-button>
           <t-button
             theme="default"
             class="!rounded-lg shadow-sm"
@@ -286,6 +353,24 @@ watch(
             保存并关闭
           </t-button>
         </div>
+      </div>
+    </template>
+  </t-dialog>
+
+  <t-dialog
+    v-model:visible="showCloseConfirm"
+    header="存在未保存的修改"
+    width="420px"
+    attach="body"
+    :close-on-overlay-click="false"
+    :close-on-esc-keydown="false"
+  >
+    <div class="text-[var(--td-text-color-secondary)] py-2">关闭编辑器前，请选择如何处理未保存的修改。</div>
+    <template #footer>
+      <div class="flex justify-end gap-2">
+        <t-button variant="outline" theme="default" class="!rounded-lg" @click="showCloseConfirm = false">取消</t-button>
+        <t-button variant="outline" theme="default" class="!rounded-lg" @click="handleDiscard">放弃修改</t-button>
+        <t-button theme="primary" class="!rounded-lg shadow-sm" :loading="props.loading" @click="handleSaveAndClose">保存并关闭</t-button>
       </div>
     </template>
   </t-dialog>

--- a/MSLX.WebPanel/src/pages/instance/files/components/FileUploader.vue
+++ b/MSLX.WebPanel/src/pages/instance/files/components/FileUploader.vue
@@ -225,14 +225,14 @@ const handleStartUpload = () => {
   const displayNames = conflicts.slice(0, 10).join('、');
   const moreText = conflicts.length > 10 ? ` 等 ${conflicts.length} 项` : '';
   const confirmDialog = DialogPlugin.confirm({
-    header: '确认覆盖上传',
-    body: `检测到 ${conflicts.length} 个同名顶层目标：${displayNames}${moreText}。继续上传将按服务端现有规则覆盖，是否继续？`,
-    theme: 'warning',
-    onConfirm: () => {
-      confirmDialog.hide();
-      processQueue();
-    },
-  });
+      header: '确认覆盖上传',
+      body: `检测到 ${conflicts.length} 个同名顶层目标：${displayNames}${moreText}。继续上传将覆盖原文件，是否继续？`,
+      theme: 'warning',
+      onConfirm: () => {
+        confirmDialog.hide();
+        processQueue();
+      },
+    });
 };
 
 const processQueue = async () => {

--- a/MSLX.WebPanel/src/pages/instance/files/components/FileUploader.vue
+++ b/MSLX.WebPanel/src/pages/instance/files/components/FileUploader.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onUnmounted, ref } from 'vue';
+import { computed, onUnmounted, ref, watch } from 'vue';
 import {
   CheckCircleFilledIcon,
   ClearIcon,
@@ -14,7 +14,7 @@ import {
   PlayCircleIcon,
   ServiceIcon,
 } from 'tdesign-icons-vue-next';
-import { MessagePlugin } from 'tdesign-vue-next';
+import { DialogPlugin, MessagePlugin } from 'tdesign-vue-next';
 import { finishUpload, initUpload, saveUploadedFile, uploadChunk } from '@/api/files';
 
 const props = withDefaults(
@@ -22,6 +22,8 @@ const props = withDefaults(
     visible: boolean;
     instanceId: number;
     currentPath: string;
+    initialItems?: Array<{ file: File; path: string }>;
+    existingTopLevelNames?: string[];
     allowFolder?: boolean;
   }>(),
   {
@@ -121,6 +123,10 @@ const totalProgress = computed(() => {
 });
 
 const hasPending = computed(() => tasks.value.some((t) => t.status === 'pending' || t.status === 'error'));
+const conflictTopLevelNames = computed(() => {
+  const existingNames = new Set(props.existingTopLevelNames || []);
+  return [...new Set(tasks.value.map((task) => task.path.split('/')[0]).filter((name) => existingNames.has(name)))];
+});
 
 const handleSelectFiles = () => fileInputRef.value?.click();
 const handleSelectFolder = () => folderInputRef.value?.click();
@@ -185,7 +191,8 @@ const readAllDirectoryEntries = async (dirReader: any) => {
   return entries;
 };
 
-const addTasksToQueue = (items: { file: File; path: string }[]) => {
+const addTasksToQueue = (items: { file: File; path: string }[], replace = false) => {
+  if (replace) tasks.value = [];
   items.forEach(({ file, path }) => {
     if (tasks.value.some((t) => t.path === path && t.file.size === file.size && t.status !== 'error')) return;
     tasks.value.push({
@@ -197,6 +204,34 @@ const addTasksToQueue = (items: { file: File; path: string }[]) => {
       committedBytes: 0,
       speed: '',
     });
+  });
+};
+
+watch(
+  () => [props.visible, props.initialItems] as const,
+  ([visible, initialItems]) => {
+    if (visible && initialItems?.length) addTasksToQueue(initialItems, true);
+  },
+);
+
+const handleStartUpload = () => {
+  if (isUploading.value || !hasPending.value) return;
+  if (conflictTopLevelNames.value.length === 0) {
+    processQueue();
+    return;
+  }
+
+  const conflicts = conflictTopLevelNames.value;
+  const displayNames = conflicts.slice(0, 10).join('、');
+  const moreText = conflicts.length > 10 ? ` 等 ${conflicts.length} 项` : '';
+  const confirmDialog = DialogPlugin.confirm({
+    header: '确认覆盖上传',
+    body: `检测到 ${conflicts.length} 个同名顶层目标：${displayNames}${moreText}。继续上传将按服务端现有规则覆盖，是否继续？`,
+    theme: 'warning',
+    onConfirm: () => {
+      confirmDialog.hide();
+      processQueue();
+    },
   });
 };
 
@@ -458,7 +493,7 @@ onUnmounted(() => tasks.value.forEach((t) => t.abortController?.abort()));
             size="small"
             class="!rounded-md shadow-sm"
             :disabled="!hasPending || isUploading"
-            @click="processQueue"
+            @click="handleStartUpload"
           >
             <template #icon><play-circle-icon /></template> {{ isUploading ? '上传中...' : '开始上传' }}
           </t-button>

--- a/MSLX.WebPanel/src/pages/instance/files/index.vue
+++ b/MSLX.WebPanel/src/pages/instance/files/index.vue
@@ -87,6 +87,8 @@ const newFolderName = ref('');
 const editorFileName = ref('');
 const editorContent = ref('');
 const isSaving = ref(false);
+const editorSaveSuccess = ref(0);
+const editorDirty = ref(false);
 const previewFileName = ref('');
 const previewUrl = ref('');
 const newFileName = ref('');
@@ -272,6 +274,7 @@ const handleSaveFile = async (newContent: string, closeDialog: boolean = true) =
   try {
     const fullPath = currentPath.value ? `${currentPath.value}/${editorFileName.value}` : editorFileName.value;
     await saveFileContent(instanceId.value, fullPath, newContent);
+    editorSaveSuccess.value += 1;
     MessagePlugin.success('保存成功');
     if (closeDialog) showEditor.value = false;
     handleRefresh();
@@ -687,13 +690,40 @@ watch(
 );
 
 onBeforeRouteLeave((to, _from, next) => {
-  if (to.name === 'InstanceFiles' || !to.query.path) {
+  if (to.name === 'InstanceFiles') {
     next();
     return;
   }
 
-  const { path: _path, ...query } = to.query;
-  next({ path: to.path, query, hash: to.hash, replace: true });
+  const continueLeave = () => {
+    if (!to.query.path) {
+      next();
+      return;
+    }
+
+    const { path: _path, ...query } = to.query;
+    next({ path: to.path, query, hash: to.hash, replace: true });
+  };
+
+  if (!editorDirty.value) {
+    continueLeave();
+    return;
+  }
+
+  const confirmDialog = DialogPlugin.confirm({
+    header: '存在未保存的修改',
+    body: '离开文件管理将放弃编辑器中的未保存修改，是否继续？',
+    theme: 'default',
+    cancelBtn: '取消',
+    confirmBtn: '放弃修改',
+    onCancel: () => next(false),
+    onConfirm: () => {
+      confirmDialog.hide();
+      showEditor.value = false;
+      editorDirty.value = false;
+      continueLeave();
+    },
+  });
 });
 
 watch(instanceId, async () => {
@@ -1039,6 +1069,8 @@ onUnmounted(() => {
       :file-name="editorFileName"
       :content="editorContent"
       :loading="isSaving"
+      :save-success="editorSaveSuccess"
+      @dirty-change="editorDirty = $event"
       @save="handleSaveFile"
     />
     <t-dialog v-model:visible="showCreateDialog" header="新建文件" :on-confirm="handleConfirmCreate">

--- a/MSLX.WebPanel/src/pages/instance/files/index.vue
+++ b/MSLX.WebPanel/src/pages/instance/files/index.vue
@@ -62,6 +62,9 @@ const loading = ref(false);
 const fileList = ref<FilesListModel[]>([]);
 const currentPath = ref('');
 const selectedRowKeys = ref<string[]>([]);
+const isFileDragOver = ref(false);
+const fileDragCounter = ref(0);
+const droppedUploadItems = ref<Array<{ file: File; path: string }>>([]);
 
 // 屏幕响应式状态
 const screenWidth = ref(window.innerWidth);
@@ -465,6 +468,88 @@ const handlePermissionSuccess = () => {
 };
 
 const handleUploadSuccess = () => handleRefresh();
+const handleUploaderVisibleChange = (visible: boolean) => {
+  showBatchUploader.value = visible;
+  if (!visible) droppedUploadItems.value = [];
+};
+
+const isFileDragEvent = (event: DragEvent) => Array.from(event.dataTransfer?.types || []).includes('Files');
+
+const handleFileDragEnter = (event: DragEvent) => {
+  if (!isFileDragEvent(event)) return;
+  fileDragCounter.value += 1;
+  isFileDragOver.value = true;
+};
+
+const handleFileDragLeave = (event: DragEvent) => {
+  if (!isFileDragEvent(event)) return;
+  fileDragCounter.value = Math.max(0, fileDragCounter.value - 1);
+  isFileDragOver.value = fileDragCounter.value > 0;
+};
+
+const resetFileDragState = () => {
+  fileDragCounter.value = 0;
+  isFileDragOver.value = false;
+};
+
+const readAllDirectoryEntries = async (dirReader: FileSystemDirectoryReader) => {
+  const entries: FileSystemEntry[] = [];
+  let batch: FileSystemEntry[];
+  do {
+    batch = await new Promise<FileSystemEntry[]>((resolve, reject) => dirReader.readEntries(resolve, reject));
+    entries.push(...batch);
+  } while (batch.length > 0);
+  return entries;
+};
+
+const traverseDroppedEntry = async (entry: FileSystemEntry, queue: Array<{ file: File; path: string }>): Promise<number> => {
+  if (entry.isFile) {
+    const file = await new Promise<File>((resolve, reject) => (entry as FileSystemFileEntry).file(resolve, reject));
+    queue.push({ file, path: entry.fullPath.replace(/^\//, '') });
+    return 0;
+  }
+
+  const entries = await readAllDirectoryEntries((entry as FileSystemDirectoryEntry).createReader());
+  if (entries.length === 0) return 1;
+
+  let emptyDirectoryCount = 0;
+  for (const subEntry of entries) {
+    emptyDirectoryCount += await traverseDroppedEntry(subEntry, queue);
+  }
+  return emptyDirectoryCount;
+};
+
+const handleFileDrop = async (event: DragEvent) => {
+  resetFileDragState();
+  const items = event.dataTransfer?.items;
+  if (!items) return;
+
+  const entries = Array.from(items)
+    .map((item) => item.webkitGetAsEntry())
+    .filter((entry): entry is FileSystemEntry => entry !== null);
+  const queue: Array<{ file: File; path: string }> = [];
+  let emptyDirectoryCount = 0;
+
+  try {
+    for (const entry of entries) {
+      emptyDirectoryCount += await traverseDroppedEntry(entry, queue);
+    }
+  } catch {
+    MessagePlugin.error('读取拖入文件失败');
+    return;
+  }
+
+  if (queue.length === 0) {
+    MessagePlugin.warning('未发现可上传文件，空文件夹暂不支持上传');
+    return;
+  }
+  if (emptyDirectoryCount > 0) {
+    MessagePlugin.warning(`检测到 ${emptyDirectoryCount} 个空文件夹，当前上传不支持创建空目录`);
+  }
+
+  droppedUploadItems.value = queue;
+  showBatchUploader.value = true;
+};
 
 // ———— 剪贴板 ——————
 const clipboard = ref<string[]>([]); // 存储被复制/剪切的文件名(相对路径)
@@ -702,7 +787,11 @@ onUnmounted(() => {
       </div>
 
       <div
-        class="flex-1 w-full bg-transparent overflow-hidden [&_.t-table]:!border-t-0 [&_.t-table\_\_header]:!border-t-0 [&_.t-table\_\_header>tr>th]:!border-t-0"
+        class="relative flex-1 w-full bg-transparent overflow-hidden [&_.t-table]:!border-t-0 [&_.t-table\_\_header]:!border-t-0 [&_.t-table\_\_header>tr>th]:!border-t-0"
+        @dragenter.prevent="handleFileDragEnter"
+        @dragover.prevent
+        @dragleave.prevent="handleFileDragLeave"
+        @drop.prevent="handleFileDrop"
       >
         <t-table
           v-model:selected-row-keys="selectedRowKeys"
@@ -810,6 +899,13 @@ onUnmounted(() => {
             </div>
           </template>
         </t-table>
+        <div
+          v-if="isFileDragOver"
+          class="absolute inset-0 z-20 flex flex-col items-center justify-center border-2 border-dashed border-[var(--color-primary)] bg-[var(--color-primary)]/10 pointer-events-none"
+        >
+          <cloud-upload-icon size="48px" class="text-[var(--color-primary)]" />
+          <span class="mt-3 text-sm font-medium text-[var(--td-text-color-primary)]">释放以上传文件或文件夹</span>
+        </div>
       </div>
     </div>
 
@@ -940,9 +1036,12 @@ onUnmounted(() => {
       <t-input v-model="renameNewName" placeholder="输入新名称" :autofocus="true" @enter="handleConfirmRename" />
     </t-dialog>
     <file-uploader
-      v-model:visible="showBatchUploader"
+      :visible="showBatchUploader"
       :instance-id="instanceId"
       :current-path="currentPath"
+      :initial-items="droppedUploadItems"
+      :existing-top-level-names="fileList.map((item) => item.name)"
+      @update:visible="handleUploaderVisibleChange"
       @success="handleUploadSuccess"
     />
     <image-preview v-model:visible="showImagePreview" :file-name="previewFileName" :image-blob-url="previewUrl" />

--- a/MSLX.WebPanel/src/pages/instance/files/index.vue
+++ b/MSLX.WebPanel/src/pages/instance/files/index.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
-import { useRoute, useRouter } from 'vue-router';
+import { onBeforeRouteLeave, useRoute, useRouter } from 'vue-router';
 import {
   AppIcon,
   CloudUploadIcon,
@@ -668,6 +668,8 @@ const filteredFileList = computed(() => {
 watch(
   () => route.query.path,
   async (newPathQuery) => {
+    if (route.name !== 'InstanceFiles') return;
+
     const targetPath = (newPathQuery as string) || '';
 
     if (targetPath === currentPath.value && fileList.value.length > 0) return;
@@ -683,6 +685,16 @@ watch(
   },
   { immediate: true },
 );
+
+onBeforeRouteLeave((to, _from, next) => {
+  if (to.name === 'InstanceFiles' || !to.query.path) {
+    next();
+    return;
+  }
+
+  const { path: _path, ...query } = to.query;
+  next({ path: to.path, query, hash: to.hash, replace: true });
+});
 
 watch(instanceId, async () => {
   if (route.name !== 'InstanceFiles') return;

--- a/MSLX.WebPanel/src/style/tailwind/components/dialog.css
+++ b/MSLX.WebPanel/src/style/tailwind/components/dialog.css
@@ -11,12 +11,18 @@
 }
 
 .t-dialog__header-content {
-  @apply flex items-center gap-2;
+  @apply flex items-start gap-2;
 }
 
 /* 针对 Danger 类型的图标颜色 */
+.t-dialog__header-content .t-icon-error-circle-filled,
+.t-dialog__header-content .t-icon-info-circle-filled,
+.t-dialog__header-content svg {
+  @apply !text-xl shrink-0 mt-[2px];
+}
+
 .t-dialog__header-content .t-icon-error-circle-filled {
-  @apply !text-red-500 !text-xl;
+  @apply !text-red-500;
 }
 
 /* 内容区 */


### PR DESCRIPTION
## 改动内容

1. **拖拽文件上传**：支持拖拽文件/文件夹上传，包含悬浮提示，上传前检测文件名冲突
2. **Ctrl+S 快捷键保存**：文件编辑器支持 Ctrl/Cmd+S 快捷保存
3. **未保存更改提示**：文件修改后在文件名旁显示标识，关闭前弹出确认提醒(原有弹出提醒没覆盖到刷新网页、ESC取消操作，此次更新全部覆盖)

https://github.com/user-attachments/assets/8236acc4-382e-44c1-9b78-7596d586425d

## 关联 Issue

Closes #180
Closes #178